### PR TITLE
Install cs2cswrapper library to /usr/lib

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ export TOMCAT_HOME="/opt/tomcat"
 
 cd /home/carma-cloud/src/cc/geosrv
 gcc -c -std=c11 -fPIC -Wall -I "${JAVA_HOME}/include/" -I "${JAVA_HOME}/include/linux/" -I /tmp/proj/src/ cs2cswrapper.c
-gcc -shared cs2cswrapper.o -lproj -o /usr/local/lib/libcs2cswrapper.so
+gcc -shared cs2cswrapper.o -lproj -o /usr/lib/libcs2cswrapper.so
 
 mkdir -p "${TOMCAT_HOME}/webapps/carmacloud/ROOT" 
 cd /home


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Default JNI search path does not include /usr/local/lib. Updated build script to place projection library wrapper in /usr/lib.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

CXC-76

## Motivation and Context

CARMA Cloud should automatically process XODR files into traffic controls. Over the course of testing, CircleCI process was replaced with GitHub actions, and the new build script placed the projection library dependency outside the Java JNI search path.

## How Has This Been Tested?

A Docker image was created from the hotfix branch, and a Docker compose was created to attach testing volumes, and verify that traffic controls were created, logged, and displayed on the UI.

## Types of changes

Technically, not a code change, but a build script change that updates the deployment configuration.

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
